### PR TITLE
Add backend README and tidy frontend main file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# lasereyesbtc
+# LaserEyesBTC
+
+This repository contains a simple Angular frontend and Express backend that demonstrates a basic Lightning Network integration. The frontend lets users add "laser eyes" to an uploaded picture while the backend provides endpoints for creating and checking LNbits invoices.
+
+```
+backend/  - Express server exposing /invoice endpoints
+frontend/ - Angular application with the laser editor
+```
+
+Both projects include Dockerfiles for containerized builds.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,20 @@
+# Backend
+
+This directory contains the Express server that provides API endpoints for creating and verifying LNbits invoices.
+
+## Running locally
+
+Install dependencies and start the server:
+
+```bash
+npm install
+node backendserver.js
+```
+
+Set the following environment variables to connect to your LNbits instance:
+
+- `LNBITS_URL` – base URL of the LNbits server
+- `LNBITS_INVOICE_KEY` – invoice/read key
+- `LNBITS_ADMIN_KEY` – admin key for verifying payments
+
+The server listens on `PORT` (default 3000) and exposes `/invoice` endpoints.

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -4,3 +4,4 @@ import { App } from './app/app';
 
 bootstrapApplication(App, appConfig)
   .catch((err) => console.error(err));
+


### PR DESCRIPTION
## Summary
- document project in top-level README
- add README describing backend server usage
- ensure `frontend/src/main.ts` ends with a newline

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850b397f72c8329ab86d3244084c36b