### PR TITLE
Fix Angular tsconfig and document backend start steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,22 @@ frontend/ - Angular application with the laser editor
 ```
 
 Both projects include Dockerfiles for containerized builds.
+
+## Starting the backend
+
+To run the API locally:
+
+```bash
+cd backend
+npm install
+node backendserver.js
+```
+
+The server requires the following environment variables to be defined:
+
+- `LNBITS_URL` – base URL of your LNbits instance
+- `LNBITS_INVOICE_KEY` – invoice/read key
+- `LNBITS_ADMIN_KEY` – admin key used to verify payments
+- `PORT` (optional) – port to listen on (defaults to 3000)
+
+After starting, the endpoints will be available at `http://localhost:PORT`.

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,34 +1,9 @@
-/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
-/* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
 {
-  "compileOnSave": false,
-  "compilerOptions": {
-    "strict": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true,
-    "isolatedModules": true,
-    "experimentalDecorators": true,
-    "importHelpers": true,
-    "target": "ES2022",
-    "module": "preserve"
-  },
-  "angularCompilerOptions": {
-    "enableI18nLegacyMessageIdFormat": false,
-    "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "typeCheckHostBindings": true,
-    "strictTemplates": true
-  },
-  "files": [],
-  "references": [
-    {
-      "path": "./tsconfig.app.json"
-    },
-    {
-      "path": "./tsconfig.spec.json"
-    }
+  "extends": "./tsconfig.json",
+  "files": [
+    "src/main.ts"
+  ],
+  "include": [
+    "src/**/*.ts"
   ]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "target": "ES2022",
+    "module": "preserve"
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "typeCheckHostBindings": true,
+    "strictTemplates": true
+  }
+}

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -1,5 +1,3 @@
-/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
-/* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {


### PR DESCRIPTION
## Summary
- fix Angular `tsconfig` so main.ts is compiled
- document how to start the backend in the main README

## Testing
- `npm test` (fails: `ng` not found)
- `npm test` in backend (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6850b4f446e483298222983553742f4c