### PR TITLE
Fix overlay styling

### DIFF
--- a/frontend/src/app/laser-editor/laser-editor.ts
+++ b/frontend/src/app/laser-editor/laser-editor.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef } from '@angular/core';
+import { Component, ElementRef, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import html2canvas from 'html2canvas';
 
@@ -11,7 +11,8 @@ interface Laser {
   selector: 'app-laser-editor',
   imports: [CommonModule],
   templateUrl: './laser-editor.html',
-  styleUrls: ['./laser-editor.css']
+  styleUrls: ['./laser-editor.css'],
+  encapsulation: ViewEncapsulation.None
 })
 export class LaserEditor {
   imageSrc: string | null = null;


### PR DESCRIPTION
## Summary
- fix overlay CSS encapsulation so dynamically created eye-glow div inherits styles

## Testing
- `npm test` (fails: No Chrome binary)
- `npm test` in backend (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68515fbc38c4832994e30b2c57572bf1