### PR TITLE
Improve laser editor shape and resizing

### DIFF
--- a/frontend/src/app/laser-editor/laser-editor.css
+++ b/frontend/src/app/laser-editor/laser-editor.css
@@ -22,10 +22,20 @@
   position: absolute;
   width: 30px;
   height: 30px;
-  border-radius: 50%;
-  background: radial-gradient(circle, yellow 0%, red 60%, red 100%);
+  border-radius: 60% 40% 70% 30% / 30% 70% 30% 70%;
+  background: radial-gradient(circle at 30% 30%, yellow 0%, red 60%, red 100%);
   box-shadow: 0 0 10px 4px red;
   cursor: grab;
   z-index: 2;
+}
+
+.laser.selected {
+  border: 1px dashed white;
+}
+
+.instructions {
+  margin-left: 0.5rem;
+  font-size: 0.9rem;
+  color: #555;
 }
 

--- a/frontend/src/app/laser-editor/laser-editor.html
+++ b/frontend/src/app/laser-editor/laser-editor.html
@@ -5,5 +5,6 @@
   <div class="image-container">
     <img *ngIf="imageSrc" [src]="imageSrc" alt="uploaded" (load)="onImageLoaded()">
   </div>
+  <p class="instructions">Pressione Ctrl + + ou Ctrl + - para redimensionar o laser selecionado.</p>
 </div>
 <button (click)="download()">Download</button>

--- a/frontend/src/app/laser-editor/laser-editor.ts
+++ b/frontend/src/app/laser-editor/laser-editor.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewEncapsulation } from '@angular/core';
+import { Component, ElementRef, HostListener, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import html2canvas from 'html2canvas';
 
@@ -20,6 +20,7 @@ export class LaserEditor {
   overlays: HTMLElement[] = [];
   dragOffsets: { x: number; y: number }[] = [];
   draggingIndex: number | null = null;
+  selectedIndex: number | null = null;
 
   constructor(private host: ElementRef<HTMLElement>) {}
 
@@ -43,6 +44,8 @@ export class LaserEditor {
       div.style.left = '50%';
       div.style.top = '50%';
       div.style.transform = 'translate(-50%, -50%)';
+      div.style.width = '30px';
+      div.style.height = '30px';
       div.addEventListener('pointerdown', this.startDrag.bind(this));
       div.addEventListener('pointermove', this.onDrag.bind(this));
       div.addEventListener('pointerup', this.endDrag.bind(this));
@@ -57,6 +60,7 @@ export class LaserEditor {
     const target = event.target as HTMLElement;
     const index = parseInt(target.dataset['index'] || '0', 10);
     this.draggingIndex = index;
+    this.selectOverlay(index);
     const rect = target.getBoundingClientRect();
     this.dragOffsets[index] = {
       x: event.clientX - rect.left,
@@ -82,6 +86,36 @@ export class LaserEditor {
   endDrag(event: PointerEvent) {
     (event.target as HTMLElement).releasePointerCapture(event.pointerId);
     this.draggingIndex = null;
+  }
+
+  selectOverlay(index: number) {
+    this.selectedIndex = index;
+    this.overlays.forEach((o, i) => {
+      if (i === index) {
+        o.classList.add('selected');
+      } else {
+        o.classList.remove('selected');
+      }
+    });
+  }
+
+  @HostListener('window:keydown', ['$event'])
+  onKeyDown(event: KeyboardEvent) {
+    if (this.selectedIndex === null) return;
+    const overlay = this.overlays[this.selectedIndex];
+    if (!overlay) return;
+    if (!(event.ctrlKey || event.metaKey)) return;
+    const width = parseFloat(overlay.style.width || getComputedStyle(overlay).width);
+    const height = parseFloat(overlay.style.height || getComputedStyle(overlay).height);
+    if (event.key === '-' || event.key === '_') {
+      overlay.style.width = width * 0.9 + 'px';
+      overlay.style.height = height * 0.9 + 'px';
+      event.preventDefault();
+    } else if (event.key === '=' || event.key === '+') {
+      overlay.style.width = width * 1.1 + 'px';
+      overlay.style.height = height * 1.1 + 'px';
+      event.preventDefault();
+    }
   }
 
   async download() {


### PR DESCRIPTION
## Summary
- tweak eye glow to have irregular edges
- add dashed frame when a laser is selected
- allow Ctrl+`+` or Ctrl+`-` to resize the selected laser
- show instructions next to the image

## Testing
- `npm test` in `backend` *(fails: no test specified)*
- `npm test` in `frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685169501cd883299603a3ce8b2b1251