### PR TITLE
Fix download output and revert eye format

### DIFF
--- a/frontend/src/app/laser-editor/laser-editor.css
+++ b/frontend/src/app/laser-editor/laser-editor.css
@@ -22,20 +22,10 @@
   position: absolute;
   width: 30px;
   height: 30px;
-  border-radius: 60% 40% 70% 30% / 30% 70% 30% 70%;
-  background: radial-gradient(circle at 30% 30%, yellow 0%, red 60%, red 100%);
+  border-radius: 50%;
+  background: radial-gradient(circle, yellow 0%, red 60%, red 100%);
   box-shadow: 0 0 10px 4px red;
   cursor: grab;
   z-index: 2;
-}
-
-.laser.selected {
-  border: 1px dashed white;
-}
-
-.instructions {
-  margin-left: 0.5rem;
-  font-size: 0.9rem;
-  color: #555;
 }
 

--- a/frontend/src/app/laser-editor/laser-editor.html
+++ b/frontend/src/app/laser-editor/laser-editor.html
@@ -5,6 +5,5 @@
   <div class="image-container">
     <img *ngIf="imageSrc" [src]="imageSrc" alt="uploaded" (load)="onImageLoaded()">
   </div>
-  <p class="instructions">Pressione Ctrl + + ou Ctrl + - para redimensionar o laser selecionado.</p>
 </div>
 <button (click)="download()">Download</button>

--- a/frontend/src/app/laser-editor/laser-editor.ts
+++ b/frontend/src/app/laser-editor/laser-editor.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, HostListener, ViewEncapsulation } from '@angular/core';
+import { Component, ElementRef, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import html2canvas from 'html2canvas';
 
@@ -20,7 +20,6 @@ export class LaserEditor {
   overlays: HTMLElement[] = [];
   dragOffsets: { x: number; y: number }[] = [];
   draggingIndex: number | null = null;
-  selectedIndex: number | null = null;
 
   constructor(private host: ElementRef<HTMLElement>) {}
 
@@ -44,8 +43,6 @@ export class LaserEditor {
       div.style.left = '50%';
       div.style.top = '50%';
       div.style.transform = 'translate(-50%, -50%)';
-      div.style.width = '30px';
-      div.style.height = '30px';
       div.addEventListener('pointerdown', this.startDrag.bind(this));
       div.addEventListener('pointermove', this.onDrag.bind(this));
       div.addEventListener('pointerup', this.endDrag.bind(this));
@@ -60,7 +57,6 @@ export class LaserEditor {
     const target = event.target as HTMLElement;
     const index = parseInt(target.dataset['index'] || '0', 10);
     this.draggingIndex = index;
-    this.selectOverlay(index);
     const rect = target.getBoundingClientRect();
     this.dragOffsets[index] = {
       x: event.clientX - rect.left,
@@ -88,42 +84,15 @@ export class LaserEditor {
     this.draggingIndex = null;
   }
 
-  selectOverlay(index: number) {
-    this.selectedIndex = index;
-    this.overlays.forEach((o, i) => {
-      if (i === index) {
-        o.classList.add('selected');
-      } else {
-        o.classList.remove('selected');
-      }
-    });
-  }
-
-  @HostListener('window:keydown', ['$event'])
-  onKeyDown(event: KeyboardEvent) {
-    if (this.selectedIndex === null) return;
-    const overlay = this.overlays[this.selectedIndex];
-    if (!overlay) return;
-    if (!(event.ctrlKey || event.metaKey)) return;
-    const width = parseFloat(overlay.style.width || getComputedStyle(overlay).width);
-    const height = parseFloat(overlay.style.height || getComputedStyle(overlay).height);
-    if (event.key === '-' || event.key === '_') {
-      overlay.style.width = width * 0.9 + 'px';
-      overlay.style.height = height * 0.9 + 'px';
-      event.preventDefault();
-    } else if (event.key === '=' || event.key === '+') {
-      overlay.style.width = width * 1.1 + 'px';
-      overlay.style.height = height * 1.1 + 'px';
-      event.preventDefault();
-    }
-  }
-
   async download() {
     const container = this.host.nativeElement.querySelector(
       '.image-container'
     ) as HTMLElement;
     if (!container) return;
-    const canvas = await html2canvas(container);
+    const canvas = await html2canvas(container, {
+      useCORS: true,
+      backgroundColor: null,
+    });
     const link = document.createElement('a');
     link.href = canvas.toDataURL('image/png');
     link.download = 'laser-eyes.png';


### PR DESCRIPTION
## Summary
- revert irregular laser shape and remove overlay selection
- fix html2canvas capture so downloaded image matches on-screen output

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68516dcbf62c8329b3d7484a55d4946e