### PR TITLE
Switch overlay to use red eye image

### DIFF
--- a/frontend/src/app/laser-editor/laser-editor.css
+++ b/frontend/src/app/laser-editor/laser-editor.css
@@ -22,9 +22,9 @@
   position: absolute;
   width: 30px;
   height: 30px;
-  border-radius: 50%;
-  background: radial-gradient(circle, yellow 0%, red 60%, red 100%);
-  box-shadow: 0 0 10px 4px red;
+  background-image: url("https://cdn.glitch.me/a3cb1903-3df2-470f-9076-c2370808ed39%2Fthumbnails%2Fglowing-red-eyes-png-4%20(1).png");
+  background-size: cover;
+  background-repeat: no-repeat;
   cursor: grab;
   z-index: 2;
 }


### PR DESCRIPTION
## Summary
- replace CSS gradient laser effect with an image overlay

## Testing
- `npm test` in `frontend` *(fails: ng not found)*
- `npm test` in `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68518bd4f2d083298d5cb69dde62d16a