### PR TITLE
Add multiple laser options and editing controls

### DIFF
--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -18,6 +18,6 @@ describe('App', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, frontend');
+    expect(compiled.querySelector('h1')?.textContent).toContain('Laser Eyes BTC');
   });
 });

--- a/frontend/src/app/laser-editor/laser-editor.css
+++ b/frontend/src/app/laser-editor/laser-editor.css
@@ -1,5 +1,7 @@
 .editor {
   margin-top: 1rem;
+  display: flex;
+  justify-content: center;
 }
 
 .image-container {
@@ -11,21 +13,30 @@
 .image-container img {
   display: block;
   width: 100%;
+  max-width: 80vw;
 }
 
 .laser {
   position: absolute;
   cursor: grab;
-}
-
-.eye-glow {
-  position: absolute;
-  width: 30px;
-  height: 30px;
-  background-image: url("https://cdn.glitch.me/a3cb1903-3df2-470f-9076-c2370808ed39%2Fthumbnails%2Fglowing-red-eyes-png-4%20(1).png");
-  background-size: cover;
+  width: 40px;
+  height: 40px;
+  background-size: contain;
   background-repeat: no-repeat;
-  cursor: grab;
-  z-index: 2;
+  background-position: center;
+}
+.laser.selected {
+  outline: 2px dashed #0f0;
+}
+.laser-options img {
+  width: 40px;
+  margin-right: 0.5rem;
+  cursor: pointer;
+}
+.laser-options img.selected {
+  outline: 2px solid #0f0;
+}
+.controls {
+  margin-top: 1rem;
 }
 

--- a/frontend/src/app/laser-editor/laser-editor.html
+++ b/frontend/src/app/laser-editor/laser-editor.html
@@ -1,9 +1,22 @@
 <div>
   <input type="file" (change)="onFileSelected($event)">
 </div>
+<div class="laser-options">
+  <img
+    *ngFor="let l of lasers"
+    [src]="l.url"
+    (click)="selectedLaser = l"
+    [class.selected]="selectedLaser === l"
+  />
+</div>
 <div class="editor">
   <div class="image-container">
     <img *ngIf="imageSrc" [src]="imageSrc" alt="uploaded" (load)="onImageLoaded()">
   </div>
 </div>
-<button (click)="download()">Download</button>
+<div class="controls">
+  <button (click)="scaleSelected(1.2)">Aumentar</button>
+  <button (click)="scaleSelected(0.8)">Diminuir</button>
+  <button (click)="deleteSelected()">Deletar</button>
+  <button (click)="download()">Download</button>
+</div>

--- a/frontend/src/app/laser-editor/laser-editor.ts
+++ b/frontend/src/app/laser-editor/laser-editor.ts
@@ -4,7 +4,7 @@ import { toPng } from 'html-to-image';
 
 interface Laser {
   id: number;
-  class: string;
+  url: string;
 }
 
 @Component({
@@ -16,10 +16,33 @@ interface Laser {
 })
 export class LaserEditor {
   imageSrc: string | null = null;
-  laser: Laser = { id: 1, class: 'eye-glow' };
+  lasers: Laser[] = [
+    {
+      id: 1,
+      url:
+        'https://cdn.glitch.me/a3cb1903-3df2-470f-9076-c2370808ed39%2Fthumbnails%2Fglowing-red-eyes-png-4%20(1).png',
+    },
+    {
+      id: 2,
+      url:
+        'https://cdn.glitch.me/a3cb1903-3df2-470f-9076-c2370808ed39%2Fthumbnails%2F879aa4d0246af1cc47f99a8c32d81773.png',
+    },
+    {
+      id: 3,
+      url:
+        'https://cdn.glitch.me/a3cb1903-3df2-470f-9076-c2370808ed39%2Fthumbnails%2F8f06a8ef61738998e73cf4d404e254d2.png',
+    },
+    {
+      id: 4,
+      url:
+        'https://cdn.glitch.me/a3cb1903-3df2-470f-9076-c2370808ed39%2Fthumbnails%2F041df0e054b8758c3bf248fdded66cb5.png',
+    },
+  ];
+  selectedLaser: Laser = this.lasers[0];
   overlays: HTMLElement[] = [];
   dragOffsets: { x: number; y: number }[] = [];
   draggingIndex: number | null = null;
+  selectedOverlayIndex: number | null = null;
 
   constructor(private host: ElementRef<HTMLElement>) {}
 
@@ -33,30 +56,43 @@ export class LaserEditor {
   }
 
   onImageLoaded() {
-    const container = this.host.nativeElement.querySelector('.image-container') as HTMLElement;
-    if (!container || this.overlays.length) return;
-
+    if (this.overlays.length) return;
     for (let i = 0; i < 2; i++) {
-      const div = document.createElement('div');
-      div.className = `laser ${this.laser.class}`;
-      div.dataset['index'] = i.toString();
-      div.style.left = '50%';
-      div.style.top = '50%';
-      div.style.transform = 'translate(-50%, -50%)';
-      div.addEventListener('pointerdown', this.startDrag.bind(this));
-      div.addEventListener('pointermove', this.onDrag.bind(this));
-      div.addEventListener('pointerup', this.endDrag.bind(this));
-      div.addEventListener('pointercancel', this.endDrag.bind(this));
-      container.appendChild(div);
-      this.overlays.push(div);
-      this.dragOffsets.push({ x: 0, y: 0 });
+      this.addOverlay();
     }
+  }
+
+  addOverlay(laser: Laser = this.selectedLaser) {
+    const container = this.host.nativeElement.querySelector('.image-container') as HTMLElement;
+    if (!container) return;
+    const div = document.createElement('div');
+    div.className = 'laser';
+    div.style.backgroundImage = `url('${laser.url}')`;
+    div.dataset['index'] = this.overlays.length.toString();
+    div.style.left = '50%';
+    div.style.top = '50%';
+    div.style.transform = 'translate(-50%, -50%)';
+    div.addEventListener('pointerdown', this.startDrag.bind(this));
+    div.addEventListener('pointermove', this.onDrag.bind(this));
+    div.addEventListener('pointerup', this.endDrag.bind(this));
+    div.addEventListener('pointercancel', this.endDrag.bind(this));
+    container.appendChild(div);
+    this.overlays.push(div);
+    this.dragOffsets.push({ x: 0, y: 0 });
   }
 
   startDrag(event: PointerEvent) {
     const target = event.target as HTMLElement;
     const index = parseInt(target.dataset['index'] || '0', 10);
     this.draggingIndex = index;
+    this.selectedOverlayIndex = index;
+    this.overlays.forEach((el, i) => {
+      if (i === index) {
+        el.classList.add('selected');
+      } else {
+        el.classList.remove('selected');
+      }
+    });
     const rect = target.getBoundingClientRect();
     this.dragOffsets[index] = {
       x: event.clientX - rect.left,
@@ -82,6 +118,25 @@ export class LaserEditor {
   endDrag(event: PointerEvent) {
     (event.target as HTMLElement).releasePointerCapture(event.pointerId);
     this.draggingIndex = null;
+  }
+
+  scaleSelected(factor: number) {
+    if (this.selectedOverlayIndex === null) return;
+    const overlay = this.overlays[this.selectedOverlayIndex];
+    const width = overlay.offsetWidth * factor;
+    const height = overlay.offsetHeight * factor;
+    overlay.style.width = `${width}px`;
+    overlay.style.height = `${height}px`;
+  }
+
+  deleteSelected() {
+    if (this.selectedOverlayIndex === null) return;
+    const overlay = this.overlays[this.selectedOverlayIndex];
+    overlay.remove();
+    this.overlays.splice(this.selectedOverlayIndex, 1);
+    this.dragOffsets.splice(this.selectedOverlayIndex, 1);
+    this.overlays.forEach((el, idx) => (el.dataset['index'] = idx.toString()));
+    this.selectedOverlayIndex = null;
   }
 
   async download() {


### PR DESCRIPTION
## Summary
- add gallery of laser images for selection
- allow scaling and deleting lasers
- center editor and avoid image cropping
- fix App title test

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68519980ba2c8329afe0281b9dd9a2bd