### PR TITLE
Implement drag resize and clean download

### DIFF
--- a/frontend/src/app/laser-editor/laser-editor.css
+++ b/frontend/src/app/laser-editor/laser-editor.css
@@ -28,6 +28,20 @@
 .laser.selected {
   outline: 2px dashed #0f0;
 }
+.resize-handle {
+  position: absolute;
+  right: -6px;
+  bottom: -6px;
+  width: 12px;
+  height: 12px;
+  background: #0f0;
+  border: 2px solid #000;
+  cursor: nwse-resize;
+  display: none;
+}
+.laser.selected .resize-handle {
+  display: block;
+}
 .laser-options img {
   width: 40px;
   margin-right: 0.5rem;

--- a/frontend/src/app/laser-editor/laser-editor.html
+++ b/frontend/src/app/laser-editor/laser-editor.html
@@ -5,7 +5,7 @@
   <img
     *ngFor="let l of lasers"
     [src]="l.url"
-    (click)="selectedLaser = l"
+    (click)="selectLaser(l)"
     [class.selected]="selectedLaser === l"
   />
 </div>


### PR DESCRIPTION
## Summary
- allow selecting a laser option to replace the current overlay image
- add resize handle so overlays can be resized by dragging
- hide selection highlights when exporting the final image

## Testing
- `npm install`
- `npm test --silent` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_6851a01e69b0832983893da66264b1a5