### PR TITLE
Implement deselection and delete shortcut

### DIFF
--- a/frontend/src/app/laser-editor/laser-editor.css
+++ b/frontend/src/app/laser-editor/laser-editor.css
@@ -8,6 +8,8 @@
   margin-top: 1rem;
   display: flex;
   justify-content: center;
+  align-items: flex-start;
+  gap: 1rem;
 }
 
 .image-container {
@@ -93,6 +95,10 @@
   color: #0f0;
   text-decoration: underline;
   margin-right: 0.5rem;
+}
+
+.editor .choose-image {
+  margin-left: 1rem;
 }
 
 .controls button {

--- a/frontend/src/app/laser-editor/laser-editor.html
+++ b/frontend/src/app/laser-editor/laser-editor.html
@@ -20,13 +20,13 @@
         (load)="onImageLoaded()"
       />
     </div>
-  </div>
-
-  <div class="controls">
-    <label class="file-link">
+    <label class="file-link choose-image">
       Choose Image
       <input type="file" (change)="onFileSelected($event)" hidden />
     </label>
+  </div>
+
+  <div class="controls">
     <button mat-button color="warn" (click)="deleteSelected()">Delete</button>
     <button mat-button color="primary" (click)="download()">Download</button>
   </div>

--- a/frontend/src/app/laser-editor/laser-editor.ts
+++ b/frontend/src/app/laser-editor/laser-editor.ts
@@ -13,7 +13,11 @@ interface Laser {
   imports: [CommonModule, MatButtonModule],
   templateUrl: './laser-editor.html',
   styleUrls: ['./laser-editor.css'],
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '(pointerdown)': 'onRootPointerDown($event)',
+    '(document:keydown)': 'onKeydown($event)'
+  }
 })
 export class LaserEditor {
   imageSrc: string | null = null;
@@ -225,6 +229,24 @@ export class LaserEditor {
     this.dragOffsets.splice(this.selectedOverlayIndex, 1);
     this.overlays.forEach((el, idx) => (el.dataset['index'] = idx.toString()));
     this.selectedOverlayIndex = null;
+  }
+
+  clearSelection() {
+    this.selectedOverlayIndex = null;
+    this.overlays.forEach(el => el.classList.remove('selected'));
+  }
+
+  onRootPointerDown(event: PointerEvent) {
+    const target = event.target as HTMLElement;
+    if (!target.closest('.laser')) {
+      this.clearSelection();
+    }
+  }
+
+  onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Delete') {
+      this.deleteSelected();
+    }
   }
 
   async download() {


### PR DESCRIPTION
## Summary
- deselect lasers when clicking outside a laser
- remove selected laser when pressing Delete
- move "Choose Image" next to the editor and style accordingly

## Testing
- `npm test --silent` (fails: ng not found)
- `npm test --silent` in backend

------
https://chatgpt.com/codex/tasks/task_e_6851b95f53188329a52a57a454014c20