### PR TITLE
Fix delete selection logic and align choose image button

### DIFF
--- a/frontend/src/app/laser-editor/laser-editor.css
+++ b/frontend/src/app/laser-editor/laser-editor.css
@@ -8,7 +8,7 @@
   margin-top: 1rem;
   display: flex;
   justify-content: center;
-  align-items: flex-start;
+  align-items: center;
   gap: 1rem;
 }
 
@@ -98,7 +98,9 @@
 }
 
 .editor .choose-image {
-  margin-left: 1rem;
+  order: -1;
+  margin-right: 1rem;
+  margin-left: 0;
 }
 
 .controls button {

--- a/frontend/src/app/laser-editor/laser-editor.ts
+++ b/frontend/src/app/laser-editor/laser-editor.ts
@@ -238,7 +238,7 @@ export class LaserEditor {
 
   onRootPointerDown(event: PointerEvent) {
     const target = event.target as HTMLElement;
-    if (!target.closest('.laser')) {
+    if (target.closest('.image-container') && !target.closest('.laser')) {
       this.clearSelection();
     }
   }


### PR DESCRIPTION
## Summary
- allow selection clearing only when clicking inside the image
- center Choose Image button on the left of the image

## Testing
- `npm test --prefix frontend --silent` *(fails: No binary for Chrome)*
- `npm test --prefix backend --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851bbfd535083298b51877223a3b295