### PR TITLE
Fix touch drag in mobile

### DIFF
--- a/frontend/src/app/laser-editor/laser-editor.css
+++ b/frontend/src/app/laser-editor/laser-editor.css
@@ -32,6 +32,7 @@
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
+  touch-action: none;
 }
 .laser.selected {
   outline: 2px dashed #0f0;
@@ -46,6 +47,7 @@
   border: 2px solid #000;
   cursor: nwse-resize;
   display: none;
+  touch-action: none;
 }
 .laser.selected .resize-handle {
   display: block;

--- a/frontend/src/app/laser-editor/laser-editor.ts
+++ b/frontend/src/app/laser-editor/laser-editor.ts
@@ -140,6 +140,7 @@ export class LaserEditor {
   }
 
   startDrag(event: PointerEvent) {
+    event.preventDefault();
     if ((event.target as HTMLElement).classList.contains('resize-handle')) return;
     const target = event.currentTarget as HTMLElement;
     const index = parseInt(target.dataset['index'] || '0', 10);
@@ -161,6 +162,7 @@ export class LaserEditor {
   }
 
   onDrag(event: PointerEvent) {
+    event.preventDefault();
     if (this.draggingIndex === null) return;
     const overlay = this.overlays[this.draggingIndex];
     if (!overlay) return;
@@ -180,6 +182,7 @@ export class LaserEditor {
   }
 
   startResize(event: PointerEvent) {
+    event.preventDefault();
     const handle = event.target as HTMLElement;
     const parent = handle.parentElement as HTMLElement;
     const index = parseInt(parent.dataset['index'] || '0', 10);
@@ -197,6 +200,7 @@ export class LaserEditor {
   }
 
   onResize(event: PointerEvent) {
+    event.preventDefault();
     if (this.resizingIndex === null || !this.resizeStart) return;
     const overlay = this.overlays[this.resizingIndex];
     const dx = event.clientX - this.resizeStart.x;


### PR DESCRIPTION
## Summary
- disable default touch actions on overlay elements
- prevent page scrolling during drag/resize events

## Testing
- `npm test --prefix frontend` *(fails: no Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_6851bf256bcc8329921832cbbe0a23bc