### PR TITLE
Add top contributor ranking page

### DIFF
--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -1,9 +1,11 @@
 <header>
   <h1>Laser Eyes</h1>
   <div class="links">
+    <a routerLink="/" >Home</a>
+    <a routerLink="/ranking">Ranking</a>
     <a href="#" (click)="openContribute(); $event.preventDefault()">Contribute</a>
   </div>
 </header>
 <main>
-  <app-laser-editor></app-laser-editor>
+  <router-outlet></router-outlet>
 </main>

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,3 +1,8 @@
 import { Routes } from '@angular/router';
+import { LaserEditor } from './laser-editor/laser-editor';
+import { Ranking } from './ranking/ranking';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', component: LaserEditor },
+  { path: 'ranking', component: Ranking }
+];

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { RouterOutlet, RouterLink } from '@angular/router';
 import { LaserEditor } from './laser-editor/laser-editor';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { ContributeDialog } from './contribute-dialog';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, LaserEditor, MatDialogModule, ContributeDialog],
+  standalone: true,
+  imports: [RouterOutlet, RouterLink, LaserEditor, MatDialogModule, ContributeDialog],
   templateUrl: './app.html',
   styleUrls: ['./app.css']
 })

--- a/frontend/src/app/laser-editor/laser-editor.ts
+++ b/frontend/src/app/laser-editor/laser-editor.ts
@@ -10,6 +10,7 @@ interface Laser {
 
 @Component({
   selector: 'app-laser-editor',
+  standalone: true,
   imports: [CommonModule, MatButtonModule],
   templateUrl: './laser-editor.html',
   styleUrls: ['./laser-editor.css'],

--- a/frontend/src/app/ranking/ranking.css
+++ b/frontend/src/app/ranking/ranking.css
@@ -1,0 +1,19 @@
+.ranking {
+  list-style: none;
+  padding: 0;
+}
+.ranking li {
+  margin: 0.5rem 0;
+}
+.position {
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+.links a {
+  margin-left: 0.5rem;
+  color: #0f0;
+  text-decoration: none;
+}
+.links a:hover {
+  text-decoration: underline;
+}

--- a/frontend/src/app/ranking/ranking.html
+++ b/frontend/src/app/ranking/ranking.html
@@ -1,0 +1,12 @@
+<h2>Top Contributors</h2>
+<ol class="ranking">
+  <li *ngFor="let c of contributors; let i = index">
+    <span class="position">{{ i + 1 }}.</span>
+    <span class="name">{{ c.name }}</span>
+    <span class="links">
+      <a [href]="c.nostr" target="_blank">nostr</a>
+      <a [href]="c.twitter" target="_blank">twitter</a>
+      <a [href]="c.instagram" target="_blank">instagram</a>
+    </span>
+  </li>
+</ol>

--- a/frontend/src/app/ranking/ranking.ts
+++ b/frontend/src/app/ranking/ranking.ts
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+interface Contributor {
+  name: string;
+  nostr: string;
+  twitter: string;
+  instagram: string;
+}
+
+@Component({
+  selector: 'app-ranking',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './ranking.html',
+  styleUrls: ['./ranking.css']
+})
+export class Ranking {
+  contributors: Contributor[] = [
+    { name: 'Contributor 1', nostr: '#', twitter: '#', instagram: '#' },
+    { name: 'Contributor 2', nostr: '#', twitter: '#', instagram: '#' },
+    { name: 'Contributor 3', nostr: '#', twitter: '#', instagram: '#' },
+    { name: 'Contributor 4', nostr: '#', twitter: '#', instagram: '#' },
+    { name: 'Contributor 5', nostr: '#', twitter: '#', instagram: '#' },
+    { name: 'Contributor 6', nostr: '#', twitter: '#', instagram: '#' },
+    { name: 'Contributor 7', nostr: '#', twitter: '#', instagram: '#' },
+    { name: 'Contributor 8', nostr: '#', twitter: '#', instagram: '#' },
+    { name: 'Contributor 9', nostr: '#', twitter: '#', instagram: '#' },
+    { name: 'Contributor 10', nostr: '#', twitter: '#', instagram: '#' }
+  ];
+}


### PR DESCRIPTION
## Summary
- turn `App` and `LaserEditor` into standalone components
- add new standalone `Ranking` component
- add routes for home and ranking pages
- update header to link to the new page

## Testing
- `npm test` *(fails: ng not found)*
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_6851e9f7aa108329bd8457366690ab6f