### PR TITLE
Add donation form feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ environment variables (values shown match the compose setup):
 - `PGUSER` (`postgres`)
 - `PGPASSWORD` (`postgres`)
 - `PGDATABASE` (`lasereyes`)
+
+When running the backend outside of Docker, the host `db` used in the
+compose setup will not resolve. Set `PGHOST` to `localhost` so the server can
+connect to your local PostgreSQL instance.

--- a/backend/backendserver.js
+++ b/backend/backendserver.js
@@ -32,6 +32,8 @@ pool.query(
     nostr TEXT,
     twitter TEXT,
     instagram TEXT,
+    nickname TEXT,
+    message TEXT,
     donated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
   )`
 ).catch((err) => console.error('DB init error', err));
@@ -73,10 +75,10 @@ app.get('/invoice/:paymentHash', async (req, res) => {
 // Save donation information
 app.post('/donations', async (req, res) => {
   try {
-    const { amount, nostr, twitter, instagram, date } = req.body;
+    const { amount, nostr, twitter, instagram, nickname, message, date } = req.body;
     await pool.query(
-      'INSERT INTO donations(amount, nostr, twitter, instagram, donated_at) VALUES($1,$2,$3,$4,$5)',
-      [amount, nostr, twitter, instagram, date]
+      'INSERT INTO donations(amount, nostr, twitter, instagram, nickname, message, donated_at) VALUES($1,$2,$3,$4,$5,$6,$7)',
+      [amount, nostr, twitter, instagram, nickname, message, date]
     );
     res.json({ status: 'ok' });
   } catch (err) {
@@ -89,7 +91,7 @@ app.post('/donations', async (req, res) => {
 app.get('/donations', async (_req, res) => {
   try {
     const { rows } = await pool.query(
-      'SELECT amount, nostr, twitter, instagram, donated_at FROM donations ORDER BY amount DESC'
+      'SELECT amount, nostr, twitter, instagram, nickname, message, donated_at FROM donations ORDER BY amount DESC'
     );
     res.json(rows);
   } catch (err) {

--- a/frontend/src/app/contribute-dialog.ts
+++ b/frontend/src/app/contribute-dialog.ts
@@ -1,20 +1,81 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
+import { MatInputModule } from '@angular/material/input';
 
 @Component({
   selector: 'app-contribute-dialog',
   standalone: true,
-  imports: [MatDialogModule, MatButtonModule],
+  imports: [MatDialogModule, MatButtonModule, MatInputModule, FormsModule],
   template: `
     <h2 mat-dialog-title>Contribute</h2>
-    <mat-dialog-content>
-      <p>Lightning: <code>lightning:example&#64;ln.example.com</code></p>
-      <p>On-chain: <code>bc1qq0qscugm4444444example</code></p>
+    <mat-dialog-content *ngIf="invoice">
+      <img [src]="qrSrc" alt="invoice QR" />
+      <p><code>{{ invoice.payment_request }}</code></p>
+      <form>
+        <mat-form-field appearance="fill">
+          <mat-label>Nickname</mat-label>
+          <input matInput [(ngModel)]="form.nickname" name="nickname" />
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>Nostr link</mat-label>
+          <input matInput [(ngModel)]="form.nostr" name="nostr" />
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>Twitter link</mat-label>
+          <input matInput [(ngModel)]="form.twitter" name="twitter" />
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>Instagram link</mat-label>
+          <input matInput [(ngModel)]="form.instagram" name="instagram" />
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>Message</mat-label>
+          <textarea matInput [(ngModel)]="form.message" name="message"></textarea>
+        </mat-form-field>
+      </form>
     </mat-dialog-content>
     <mat-dialog-actions align="end">
+      <button mat-button (click)="send()">Send</button>
       <button mat-button mat-dialog-close>Close</button>
     </mat-dialog-actions>
   `,
 })
-export class ContributeDialog {}
+export class ContributeDialog implements OnInit {
+  invoice: any = null;
+  form = { nickname: '', nostr: '', twitter: '', instagram: '', message: '' };
+
+  qrSrc = '';
+
+  async ngOnInit() {
+    try {
+      const res = await fetch('/api/invoice', { method: 'POST' });
+      if (res.ok) {
+        this.invoice = await res.json();
+        const pr = this.invoice.payment_request || this.invoice.pr;
+        this.qrSrc =
+          'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=' +
+          encodeURIComponent(pr);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async send() {
+    try {
+      await fetch('/api/donations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          amount: this.invoice?.invoice?.amount || 0,
+          ...this.form,
+          date: new Date().toISOString(),
+        }),
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+}

--- a/frontend/src/app/ranking/ranking.html
+++ b/frontend/src/app/ranking/ranking.html
@@ -9,5 +9,6 @@
       <a [href]="c.twitter" target="_blank">twitter</a>
       <a [href]="c.instagram" target="_blank">instagram</a>
     </span>
+    <span class="message" *ngIf="c.message">{{ c.message }}</span>
   </li>
 </ol>

--- a/frontend/src/app/ranking/ranking.ts
+++ b/frontend/src/app/ranking/ranking.ts
@@ -6,6 +6,7 @@ interface Contributor {
   nostr: string;
   twitter: string;
   instagram: string;
+  message: string;
   amount: number;
 }
 
@@ -25,10 +26,11 @@ export class Ranking implements OnInit {
       if (!res.ok) throw new Error('failed');
       const data = await res.json();
       this.contributors = data.map((d: any) => ({
-        name: d.twitter || d.nostr || d.instagram || 'anon',
+        name: d.nickname || d.twitter || d.nostr || d.instagram || 'anon',
         nostr: d.nostr,
         twitter: d.twitter,
         instagram: d.instagram,
+        message: d.message,
         amount: d.amount
       }));
     } catch (err) {


### PR DESCRIPTION
## Summary
- document using `PGHOST=localhost` when running locally
- store nickname and message in `donations` table
- include nickname and message when saving/fetching donations
- show messages in the ranking list
- redesign Contribute dialog with QR code and donation form

## Testing
- `npm test` (fails: ng not found)
- `npm test` in backend (fails: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68520450ddc88329ac13416b47fb8daa