### PR TITLE
Fix Angular API proxy and missing CommonModule

### DIFF
--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -1,6 +1,7 @@
 {
   "/api": {
     "target": "http://localhost:3000",
-    "secure": false
+    "secure": false,
+    "pathRewrite": { "^/api": "" }
   }
 }

--- a/frontend/src/app/contribute-dialog.ts
+++ b/frontend/src/app/contribute-dialog.ts
@@ -3,11 +3,12 @@ import { FormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatInputModule } from '@angular/material/input';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-contribute-dialog',
   standalone: true,
-  imports: [MatDialogModule, MatButtonModule, MatInputModule, FormsModule],
+  imports: [CommonModule, MatDialogModule, MatButtonModule, MatInputModule, FormsModule],
   template: `
     <h2 mat-dialog-title>Contribute</h2>
     <mat-dialog-content *ngIf="invoice">


### PR DESCRIPTION
## Summary
- add path rewrite to proxy configuration so `/api` routes map to backend
- include `CommonModule` in `ContributeDialog` imports for `*ngIf`

## Testing
- `npm test` (fails: `ng` not found)
- `npm test` in backend (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68520a25e1c88329b26cb1a6f9cbc2ba