### PR TITLE
Fix path for Angular build in Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,7 +6,9 @@ COPY . .
 RUN npm run build -- --configuration production
 
 FROM nginx:alpine
-COPY --from=build /app/dist/frontend /usr/share/nginx/html
+# Angular 20's production build outputs files under "dist/frontend/browser".
+# Copy that directory so nginx serves "index.html" from the web root.
+COPY --from=build /app/dist/frontend/browser /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- fix frontend Dockerfile to copy Angular build output correctly

## Testing
- `npm test` in backend (fails: no test specified)
- `npm test` in frontend (fails: no Chrome binary)

------
https://chatgpt.com/codex/tasks/task_e_6852893ebf008329b54bd55164f697c8