### PR TITLE
Add paid invoice gating for downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LaserEyesBTC
 
-This repository contains a simple Angular frontend and Express backend that demonstrates a basic Lightning Network integration. The frontend lets users add "laser eyes" to an uploaded picture while the backend now uses the [Coinos](https://coinos.io) API to create and verify invoices.
+This repository contains a simple Angular frontend and Express backend that demonstrates a basic Lightning Network integration. The frontend lets users add "laser eyes" to an uploaded picture while the backend now uses the [Coinos](https://coinos.io) API to create and verify invoices. Downloads of edited images are gated behind a Lightning invoice of at least **150** satoshis which is verified through the same API.
 
 ```
 backend/  - Express server exposing /invoice endpoints

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -3,11 +3,19 @@ import { RouterOutlet, RouterLink } from '@angular/router';
 import { LaserEditor } from './laser-editor/laser-editor';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { ContributeDialog } from './contribute-dialog';
+import { PayDialog } from './pay-dialog';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, RouterLink, LaserEditor, MatDialogModule, ContributeDialog],
+  imports: [
+    RouterOutlet,
+    RouterLink,
+    LaserEditor,
+    MatDialogModule,
+    ContributeDialog,
+    PayDialog,
+  ],
   templateUrl: './app.html',
   styleUrls: ['./app.css']
 })

--- a/frontend/src/app/laser-editor/laser-editor.ts
+++ b/frontend/src/app/laser-editor/laser-editor.ts
@@ -1,6 +1,8 @@
 import { Component, ElementRef, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { PayDialog } from '../pay-dialog';
 import { toPng } from 'html-to-image';
 
 interface Laser {
@@ -11,7 +13,7 @@ interface Laser {
 @Component({
   selector: 'app-laser-editor',
   standalone: true,
-  imports: [CommonModule, MatButtonModule],
+  imports: [CommonModule, MatButtonModule, MatDialogModule],
   templateUrl: './laser-editor.html',
   styleUrls: ['./laser-editor.css'],
   encapsulation: ViewEncapsulation.None,
@@ -72,7 +74,7 @@ export class LaserEditor {
   resizingIndex: number | null = null;
   resizeStart: { width: number; height: number; x: number; y: number } | null = null;
 
-  constructor(private host: ElementRef<HTMLElement>) {}
+  constructor(private host: ElementRef<HTMLElement>, private dialog: MatDialog) {}
 
   selectLaser(l: Laser) {
     this.selectedLaser = l;
@@ -254,7 +256,16 @@ export class LaserEditor {
     }
   }
 
-  async download() {
+  download() {
+    const ref = this.dialog.open(PayDialog);
+    ref.afterClosed().subscribe(paid => {
+      if (paid) {
+        this.downloadImage();
+      }
+    });
+  }
+
+  async downloadImage() {
     const container = this.host.nativeElement.querySelector(
       '.image-container'
     ) as HTMLElement;

--- a/frontend/src/app/pay-dialog.ts
+++ b/frontend/src/app/pay-dialog.ts
@@ -1,0 +1,68 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-pay-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  template: `
+    <h2 mat-dialog-title>Pay 150 sats to download</h2>
+    <mat-dialog-content *ngIf="invoice">
+      <img [src]="qrSrc" alt="invoice QR" />
+      <p><code>{{ invoice.payment_request }}</code></p>
+      <p *ngIf="checking">Checking payment...</p>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close>Cancel</button>
+    </mat-dialog-actions>
+  `,
+})
+export class PayDialog implements OnInit, OnDestroy {
+  invoice: any = null;
+  qrSrc = '';
+  checking = false;
+  interval: any;
+
+  constructor(private ref: MatDialogRef<PayDialog>) {}
+
+  async ngOnInit() {
+    try {
+      const res = await fetch('/api/invoice', { method: 'POST' });
+      if (res.ok) {
+        this.invoice = await res.json();
+        const pr = this.invoice.payment_request || this.invoice.pr;
+        this.qrSrc =
+          'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=' +
+          encodeURIComponent(pr);
+        const hash = this.invoice.payment_hash || this.invoice.r_hash;
+        if (hash) {
+          this.checking = true;
+          this.interval = setInterval(() => this.poll(hash), 5000);
+        }
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async poll(hash: string) {
+    try {
+      const res = await fetch('/api/invoice/' + hash);
+      if (res.ok) {
+        const data = await res.json();
+        if (data.state === 'paid' || data.settled || data.paid) {
+          clearInterval(this.interval);
+          this.ref.close(true);
+        }
+      }
+    } catch {}
+  }
+
+  ngOnDestroy() {
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- require a 150 sat invoice before downloading edited images
- add a PayDialog component that polls Coinos for payment
- hook up the download button to open PayDialog
- update README with note about payment requirement

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852b4c462488329871d83e6b7c12baf