### PR TITLE
Fix invoice creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ node backendserver.js
 
 The server requires the following environment variables:
 - `COINOS_URL` – base URL of your Coinos instance (default `https://coinos.io`)
-- `COINOS_API_KEY` – API key or JWT token from Coinos
+- `COINOS_API_KEY` – API key or JWT token from Coinos (added automatically as a
+  `Bearer` Authorization header if set)
 - `CHARGE_AMOUNT` – amount in satoshis per download (minimum `150`, default `150`)
 - `CHARGE_MEMO` – memo for the created invoices (default `Laser eyes download`)
 - `PORT` (optional) – port to listen on (defaults to 3000)

--- a/backend/backendserver.js
+++ b/backend/backendserver.js
@@ -44,11 +44,10 @@ app.post('/invoice', async (req, res) => {
       `${coinosUrl}/invoice`,
       { invoice: { amount: chargeAmount, memo: chargeMemo } },
       {
-        headers: {
-          // Uncomment the line below to send your Coinos API key using an env var
-          // Authorization: `Bearer ${coinosApiKey}`,
-          'Content-Type': 'application/json',
-        },
+        headers: Object.assign(
+          { 'Content-Type': 'application/json' },
+          coinosApiKey ? { Authorization: `Bearer ${coinosApiKey}` } : {}
+        ),
       },
     );
     res.json(response.data);
@@ -62,8 +61,7 @@ app.get('/invoice/:paymentHash', async (req, res) => {
   try {
     const { paymentHash } = req.params;
     const response = await axios.get(`${coinosUrl}/invoice/${paymentHash}`, {
-      // Uncomment the line below to include your API key when checking invoices
-      // headers: { Authorization: `Bearer ${coinosApiKey}` },
+      headers: coinosApiKey ? { Authorization: `Bearer ${coinosApiKey}` } : {},
     });
     res.json(response.data);
   } catch (err) {


### PR DESCRIPTION
## Summary
- include `COINOS_API_KEY` automatically in invoice API calls
- update README with info about the new behaviour

## Testing
- `npm test` (fails: no test specified)
- `npm test` in frontend (fails: `ng` not found)

------
https://chatgpt.com/codex/tasks/task_e_6852b6c3a7488329b3685a5e4e9d2484