### PR TITLE
Fix invoice creation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The server requires the following environment variables:
 - `COINOS_URL` – base URL of your Coinos instance (default `https://coinos.io`)
 - `COINOS_API_KEY` – API key or JWT token from Coinos (added automatically as a
   `Bearer` Authorization header if set)
+- `COINOS_USERNAME` – username to bill invoices to (required when the API key
+  alone doesn't identify a user)
 - `CHARGE_AMOUNT` – amount in satoshis per download (minimum `150`, default `150`)
 - `CHARGE_MEMO` – memo for the created invoices (default `Laser eyes download`)
 - `PORT` (optional) – port to listen on (defaults to 3000)

--- a/backend/README.md
+++ b/backend/README.md
@@ -15,6 +15,7 @@ Set the following environment variables before starting the server:
 
 - `COINOS_URL` – base URL of your Coinos instance (default `https://coinos.io`)
 - `COINOS_API_KEY` – API key or JWT token from Coinos
+- `COINOS_USERNAME` – username to bill invoices to (required by some instances)
 - `CHARGE_AMOUNT` – amount in satoshis for each invoice (minimum `150`, default `150`)
 - `CHARGE_MEMO` – memo to attach to created invoices (default `Laser eyes download`)
 

--- a/backend/backendserver.js
+++ b/backend/backendserver.js
@@ -10,6 +10,7 @@ app.use(bodyParser.json());
 
 const coinosUrl = process.env.COINOS_URL || 'https://coinos.io';
 const coinosApiKey = process.env.COINOS_API_KEY; // JWT or API key
+const coinosUsername = process.env.COINOS_USERNAME; // required by some instances
 const minAmount = 150;
 const envAmount = parseInt(process.env.CHARGE_AMOUNT || String(minAmount));
 const chargeAmount = Math.max(envAmount, minAmount); // sats
@@ -40,9 +41,13 @@ pool.query(
 
 app.post('/invoice', async (req, res) => {
   try {
+    const body = { invoice: { amount: chargeAmount, memo: chargeMemo } };
+    if (coinosUsername) {
+      body.user = { username: coinosUsername };
+    }
     const response = await axios.post(
       `${coinosUrl}/invoice`,
-      { invoice: { amount: chargeAmount, memo: chargeMemo } },
+      body,
       {
         headers: Object.assign(
           { 'Content-Type': 'application/json' },

--- a/frontend/src/app/pay-dialog.ts
+++ b/frontend/src/app/pay-dialog.ts
@@ -13,6 +13,7 @@ import { MatButtonModule } from '@angular/material/button';
       <img [src]="qrSrc" alt="invoice QR" />
       <p><code>{{ invoice.payment_request }}</code></p>
       <p *ngIf="checking">Checking payment...</p>
+      <p *ngIf="error" class="error">{{ error }}</p>
     </mat-dialog-content>
     <mat-dialog-actions align="end">
       <button mat-button mat-dialog-close>Cancel</button>
@@ -24,6 +25,7 @@ export class PayDialog implements OnInit, OnDestroy {
   qrSrc = '';
   checking = false;
   interval: any;
+  error = '';
 
   constructor(private ref: MatDialogRef<PayDialog>) {}
 
@@ -41,9 +43,13 @@ export class PayDialog implements OnInit, OnDestroy {
           this.checking = true;
           this.interval = setInterval(() => this.poll(hash), 5000);
         }
+      } else {
+        const data = await res.json().catch(() => ({}));
+        this.error = data.error || 'Failed to create invoice';
       }
     } catch (err) {
       console.error(err);
+      this.error = 'Failed to create invoice';
     }
   }
 


### PR DESCRIPTION
## Summary
- document `COINOS_USERNAME` for invoice creation
- support optional `COINOS_USERNAME` when creating invoices
- show errors in the pay dialog when invoice generation fails

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852bbaa95d883299f69d2cd67c7c7da