### PR TITLE
Handle invalid invoices

### DIFF
--- a/frontend/src/app/contribute-dialog.ts
+++ b/frontend/src/app/contribute-dialog.ts
@@ -11,9 +11,14 @@ import { CommonModule } from '@angular/common';
   imports: [CommonModule, MatDialogModule, MatButtonModule, MatInputModule, FormsModule],
   template: `
     <h2 mat-dialog-title>Contribute</h2>
-    <mat-dialog-content *ngIf="invoice">
+    <mat-dialog-content *ngIf="invoice; else errTpl">
       <img [src]="qrSrc" alt="invoice QR" />
       <p><code>{{ invoice.payment_request }}</code></p>
+      <p *ngIf="error" class="error">{{ error }}</p>
+    </mat-dialog-content>
+    <ng-template #errTpl>
+      <p *ngIf="error" class="error">{{ error }}</p>
+    </ng-template>
       <form>
         <mat-form-field appearance="fill">
           <mat-label>Nickname</mat-label>
@@ -48,6 +53,7 @@ export class ContributeDialog implements OnInit {
   form = { nickname: '', nostr: '', twitter: '', instagram: '', message: '' };
 
   qrSrc = '';
+  error = '';
 
   async ngOnInit() {
     try {
@@ -55,6 +61,10 @@ export class ContributeDialog implements OnInit {
       if (res.ok) {
         this.invoice = await res.json();
         const pr = this.invoice.payment_request || this.invoice.pr;
+        if (!pr) {
+          this.error = 'Invalid invoice received';
+          return;
+        }
         this.qrSrc =
           'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=' +
           encodeURIComponent(pr);

--- a/frontend/src/app/pay-dialog.ts
+++ b/frontend/src/app/pay-dialog.ts
@@ -9,12 +9,15 @@ import { MatButtonModule } from '@angular/material/button';
   imports: [CommonModule, MatDialogModule, MatButtonModule],
   template: `
     <h2 mat-dialog-title>Pay 150 sats to download</h2>
-    <mat-dialog-content *ngIf="invoice">
+    <mat-dialog-content *ngIf="invoice; else errTpl">
       <img [src]="qrSrc" alt="invoice QR" />
       <p><code>{{ invoice.payment_request }}</code></p>
       <p *ngIf="checking">Checking payment...</p>
       <p *ngIf="error" class="error">{{ error }}</p>
     </mat-dialog-content>
+    <ng-template #errTpl>
+      <p *ngIf="error" class="error">{{ error }}</p>
+    </ng-template>
     <mat-dialog-actions align="end">
       <button mat-button mat-dialog-close>Cancel</button>
     </mat-dialog-actions>
@@ -35,6 +38,10 @@ export class PayDialog implements OnInit, OnDestroy {
       if (res.ok) {
         this.invoice = await res.json();
         const pr = this.invoice.payment_request || this.invoice.pr;
+        if (!pr) {
+          this.error = 'Invalid invoice received';
+          return;
+        }
         this.qrSrc =
           'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=' +
           encodeURIComponent(pr);


### PR DESCRIPTION
## Summary
- show invoice errors when failing to load payment request
- validate invoice from backend before generating QR code

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c8b31fec8329bdde39da70efc976