### PR TITLE
Fix QR code generation when invoice is nested

### DIFF
--- a/frontend/src/app/contribute-dialog.ts
+++ b/frontend/src/app/contribute-dialog.ts
@@ -59,7 +59,9 @@ export class ContributeDialog implements OnInit {
     try {
       const res = await fetch('/api/invoice', { method: 'POST' });
       if (res.ok) {
-        this.invoice = await res.json();
+        const data = await res.json();
+        // Coinos may nest the actual invoice under `invoice`
+        this.invoice = data.invoice || data;
         const pr = this.invoice.payment_request || this.invoice.pr;
         if (!pr) {
           this.error = 'Invalid invoice received';
@@ -80,7 +82,7 @@ export class ContributeDialog implements OnInit {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          amount: this.invoice?.invoice?.amount || 0,
+          amount: this.invoice?.amount || 0,
           ...this.form,
           date: new Date().toISOString(),
         }),

--- a/frontend/src/app/pay-dialog.ts
+++ b/frontend/src/app/pay-dialog.ts
@@ -36,7 +36,9 @@ export class PayDialog implements OnInit, OnDestroy {
     try {
       const res = await fetch('/api/invoice', { method: 'POST' });
       if (res.ok) {
-        this.invoice = await res.json();
+        const data = await res.json();
+        // Some Coinos responses wrap the invoice in an `invoice` object
+        this.invoice = data.invoice || data;
         const pr = this.invoice.payment_request || this.invoice.pr;
         if (!pr) {
           this.error = 'Invalid invoice received';


### PR DESCRIPTION
## Summary
- handle nested `invoice` property returned by Coinos
- update donation submission to use simplified invoice object

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6852c9e6764c8329a1a261b2adbe2786