### PR TITLE
Handle Coinos bolt11 invoice field

### DIFF
--- a/frontend/src/app/contribute-dialog.ts
+++ b/frontend/src/app/contribute-dialog.ts
@@ -62,7 +62,10 @@ export class ContributeDialog implements OnInit {
         const data = await res.json();
         // Coinos may nest the actual invoice under `invoice`
         this.invoice = data.invoice || data;
-        const pr = this.invoice.payment_request || this.invoice.pr;
+        const pr =
+          this.invoice.payment_request ||
+          this.invoice.pr ||
+          this.invoice.bolt11;
         if (!pr) {
           this.error = 'Invalid invoice received';
           return;

--- a/frontend/src/app/pay-dialog.ts
+++ b/frontend/src/app/pay-dialog.ts
@@ -39,7 +39,10 @@ export class PayDialog implements OnInit, OnDestroy {
         const data = await res.json();
         // Some Coinos responses wrap the invoice in an `invoice` object
         this.invoice = data.invoice || data;
-        const pr = this.invoice.payment_request || this.invoice.pr;
+        const pr =
+          this.invoice.payment_request ||
+          this.invoice.pr ||
+          this.invoice.bolt11;
         if (!pr) {
           this.error = 'Invalid invoice received';
           return;


### PR DESCRIPTION
## Summary
- support `bolt11` field from Coinos invoices

## Testing
- `npm run build -- --configuration production`
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_6852cc86af28832981d1d05bbe8972a2