### PR TITLE
Fix invoice error handling

### DIFF
--- a/frontend/src/app/contribute-dialog.ts
+++ b/frontend/src/app/contribute-dialog.ts
@@ -66,9 +66,15 @@ export class ContributeDialog implements OnInit {
         const pr =
           this.invoice.payment_request ||
           this.invoice.pr ||
-          this.invoice.bolt11;
+          this.invoice.bolt11 ||
+          this.invoice.payreq ||
+          this.invoice.paymentRequest ||
+          this.invoice.request;
         if (!pr) {
-          this.error = 'Invalid invoice received';
+          this.error =
+            this.invoice.message ||
+            this.invoice.error ||
+            'Invalid invoice received';
           return;
         }
         this.qrSrc = await toDataURL(pr);

--- a/frontend/src/app/pay-dialog.ts
+++ b/frontend/src/app/pay-dialog.ts
@@ -43,9 +43,15 @@ export class PayDialog implements OnInit, OnDestroy {
         const pr =
           this.invoice.payment_request ||
           this.invoice.pr ||
-          this.invoice.bolt11;
+          this.invoice.bolt11 ||
+          this.invoice.payreq ||
+          this.invoice.paymentRequest ||
+          this.invoice.request;
         if (!pr) {
-          this.error = 'Invalid invoice received';
+          this.error =
+            this.invoice.message ||
+            this.invoice.error ||
+            'Invalid invoice received';
           return;
         }
         this.qrSrc = await toDataURL(pr);


### PR DESCRIPTION
## Summary
- show backend error message when invoice response lacks QR data

## Testing
- `npm run build`
- `npm test` *(fails: No Chrome binary)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852d0a5ebe883298b24ecd28688f509