### PR TITLE
Validate payment amount before downloading

### DIFF
--- a/frontend/src/app/pay-dialog.ts
+++ b/frontend/src/app/pay-dialog.ts
@@ -77,8 +77,21 @@ export class PayDialog implements OnInit, OnDestroy {
       if (res.ok) {
         const data = await res.json();
         if (data.state === 'paid' || data.settled || data.paid) {
-          clearInterval(this.interval);
-          this.ref.close(true);
+          const amount =
+            Number(data.amount) ||
+            Number(data.value) ||
+            Number(data.tokens) ||
+            Number(data.settle_amount) ||
+            Number(data.settled_amount) ||
+            (data.amt_paid_msat ? Number(data.amt_paid_msat) / 1000 : NaN) ||
+            (data.msatoshi ? Number(data.msatoshi) / 1000 : NaN);
+          if (isNaN(amount) || amount >= 150) {
+            clearInterval(this.interval);
+            this.ref.close(true);
+          } else {
+            this.error = 'Payment below required 150 sats';
+            clearInterval(this.interval);
+          }
         }
       }
     } catch {}


### PR DESCRIPTION
## Summary
- verify invoice amount in `PayDialog` polling

## Testing
- `npm test --prefix frontend` *(fails: ng not found)*
- `npm test --prefix backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852d5aeb7f48329b3d41a7eb5441c43