### PR TITLE
Add invoice status streaming endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -22,6 +22,17 @@ Set the following environment variables before starting the server:
 The server listens on `PORT` (default 3000) and exposes `/invoice` endpoints.
 It also provides `/donations` for posting and retrieving contributor rankings.
 
+### Streaming invoice status
+
+To monitor an invoice until it is paid you can open a Server-Sent Events stream:
+
+```bash
+curl http://localhost:3000/invoice/<HASH>/stream
+```
+
+The endpoint checks the invoice on Coinos every two seconds and emits the
+current invoice JSON. The connection closes once the invoice is paid.
+
 The following database variables configure the PostgreSQL connection (defaults
 match the `docker-compose.yml` setup):
 


### PR DESCRIPTION
## Summary
- stream invoice status via Server-Sent Events
- document the `/invoice/:hash/stream` endpoint

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in frontend (fails: ng not found)


------
https://chatgpt.com/codex/tasks/task_e_6852d8030e548329b10597482ee03d96