### PR TITLE
Fix WebSocket proxy

### DIFF
--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -2,6 +2,7 @@
   "/api": {
     "target": "http://localhost:3000",
     "secure": false,
+    "ws": true,
     "pathRewrite": { "^/api": "" }
   }
 }


### PR DESCRIPTION
## Summary
- enable WebSocket forwarding in the Angular development proxy configuration

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6852ea7b3d648329a9abbf571a466f49