### PR TITLE
Fix WebSocket invoice checks hitting HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ node backendserver.js
 ```
 
 The server requires the following environment variables:
-- `COINOS_URL` – base URL of your Coinos instance (default `https://coinos.io`)
+- `COINOS_URL` – base URL of your Coinos instance **without the `/api` path**
+  (default `https://coinos.io`). The backend automatically calls the API under
+  `/api`.
 - `COINOS_API_KEY` – API key or JWT token from Coinos (added automatically as a
   `Bearer` Authorization header if set)
 - `COINOS_USERNAME` – username to bill invoices to (required when the API key

--- a/backend/README.md
+++ b/backend/README.md
@@ -13,7 +13,9 @@ node backendserver.js
 
 Set the following environment variables before starting the server:
 
-- `COINOS_URL` – base URL of your Coinos instance (default `https://coinos.io`)
+- `COINOS_URL` – base URL of your Coinos instance **without the `/api` path**
+  (default `https://coinos.io`). The server automatically requests endpoints
+  under `/api`.
 - `COINOS_API_KEY` – API key or JWT token from Coinos
 - `COINOS_USERNAME` – username to bill invoices to (required by some instances)
 - `CHARGE_AMOUNT` – amount in satoshis for each invoice (minimum `150`, default `150`)

--- a/backend/backendserver.js
+++ b/backend/backendserver.js
@@ -48,7 +48,7 @@ app.post('/invoice', async (req, res) => {
       body.user = { username: coinosUsername };
     }
     const response = await axios.post(
-      `${coinosUrl}/invoice`,
+      `${coinosUrl}/api/invoice`,
       body,
       {
         headers: Object.assign(
@@ -67,7 +67,7 @@ app.post('/invoice', async (req, res) => {
 app.get('/invoice/:paymentHash', async (req, res) => {
   try {
     const { paymentHash } = req.params;
-    const response = await axios.get(`${coinosUrl}/invoice/${paymentHash}`, {
+    const response = await axios.get(`${coinosUrl}/api/invoice/${paymentHash}`, {
       headers: coinosApiKey ? { Authorization: `Bearer ${coinosApiKey}` } : {},
     });
     res.json(response.data);
@@ -132,7 +132,7 @@ wss.on('connection', (ws, req) => {
 
   const interval = setInterval(async () => {
     try {
-      const { data } = await axios.get(`${coinosUrl}/invoice/${paymentHash}`, { headers });
+      const { data } = await axios.get(`${coinosUrl}/api/invoice/${paymentHash}`, { headers });
       ws.send(JSON.stringify(data));
       if (checkPaid(data)) {
         clearInterval(interval);


### PR DESCRIPTION
## Summary
- call Coinos invoice endpoints under `/api`
- clarify the COINOS_URL variable docs

## Testing
- `npm test --prefix backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852ef36a3248329853b82ae2459e943