### PR TITLE
Update download button and validation

### DIFF
--- a/frontend/src/app/laser-editor/laser-editor.html
+++ b/frontend/src/app/laser-editor/laser-editor.html
@@ -28,6 +28,6 @@
 
   <div class="controls">
     <button mat-button color="warn" (click)="deleteSelected()">Delete</button>
-    <button mat-button color="primary" (click)="download()">Download</button>
+    <button mat-button color="primary" (click)="download()">Download HD</button>
   </div>
 </div>

--- a/frontend/src/app/laser-editor/laser-editor.ts
+++ b/frontend/src/app/laser-editor/laser-editor.ts
@@ -257,6 +257,10 @@ export class LaserEditor {
   }
 
   download() {
+    if (!this.imageSrc) {
+      alert('Please upload an image before downloading.');
+      return;
+    }
     const ref = this.dialog.open(PayDialog);
     ref.afterClosed().subscribe(paid => {
       if (paid) {


### PR DESCRIPTION
## Summary
- update download button text to `Download HD`
- alert users to upload an image before downloading

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6852f24a1c648329aef0d2481f422a91