### PR TITLE
Check for image before adding laser

### DIFF
--- a/frontend/src/app/laser-editor/laser-editor.ts
+++ b/frontend/src/app/laser-editor/laser-editor.ts
@@ -77,6 +77,10 @@ export class LaserEditor {
   constructor(private host: ElementRef<HTMLElement>, private dialog: MatDialog) {}
 
   selectLaser(l: Laser) {
+    if (!this.imageSrc) {
+      alert('Please upload an image before downloading.');
+      return;
+    }
     this.selectedLaser = l;
     this.addOverlay(l);
   }


### PR DESCRIPTION
## Summary
- warn if no image when choosing laser style

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f648ed748329957983cf1fa33fba