### PR TITLE
Add JP logo in footer

### DIFF
--- a/frontend/public/jp-logo.svg
+++ b/frontend/public/jp-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="white" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="60" fill="black">JP</text>
+</svg>

--- a/frontend/src/app/app.css
+++ b/frontend/src/app/app.css
@@ -22,3 +22,17 @@ main {
   align-items: center;
   text-align: center;
 }
+
+footer.credits {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem 0;
+}
+
+footer.credits img {
+  height: 2.5rem;
+  width: 2.5rem;
+  margin-left: 0.25rem;
+  border-radius: 50%;
+}

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -7,3 +7,9 @@
 <main>
   <router-outlet></router-outlet>
 </main>
+<footer class="credits">
+  <span>by </span>
+  <a href="https://jpfurlan.dev/" target="_blank" rel="noopener" class="logo-link">
+    <img src="/jp-logo.svg" alt="JP logo">
+  </a>
+</footer>


### PR DESCRIPTION
## Summary
- add circle JP logo as new asset
- show footer with JP logo link
- style footer credits section

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd1db2c808329973d2168c2987a10