### PR TITLE
Text-only footer credit with hover navigation

### DIFF
--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -8,5 +8,5 @@
   <router-outlet></router-outlet>
 </main>
 <footer class="credits">
-  <a href="https://jpfurlan.dev/" target="_blank" rel="noopener">by jp</a>
+  <span (mouseenter)="openJp()">By Jp</span>
 </footer>

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -27,4 +27,8 @@ export class App {
   openContribute() {
     this.dialog.open(ContributeDialog);
   }
+
+  openJp() {
+    window.open('https://jpfurlan.dev/', '_blank', 'noopener');
+  }
 }


### PR DESCRIPTION
## Summary
- show credit as plain text in footer
- open `jpfurlan.dev` when hovering over the credit text

## Testing
- `npm test` in `backend` *(fails: no test specified)*
- `npm test` in `frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685de3c735088329a51f1b77a37e5468