### PR TITLE
Add credit link and image selection cue

### DIFF
--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -8,5 +8,5 @@
   <router-outlet></router-outlet>
 </main>
 <footer class="credits">
-  <span (mouseenter)="openJp()">By Jp</span>
+  <span onclick="window.location.href='https://jpfurlan.dev/';">By Jp</span>
 </footer>

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -28,7 +28,4 @@ export class App {
     this.dialog.open(ContributeDialog);
   }
 
-  openJp() {
-    window.open('https://jpfurlan.dev/', '_blank', 'noopener');
-  }
 }

--- a/frontend/src/app/laser-editor/laser-editor.css
+++ b/frontend/src/app/laser-editor/laser-editor.css
@@ -109,6 +109,11 @@
   margin-left: 0;
 }
 
+.editor .choose-image::after {
+  content: ' \2191';
+  margin-left: 0.25rem;
+}
+
 .controls button {
   padding: 0.5rem 1rem;
 }


### PR DESCRIPTION
## Summary
- link directly to JP's site from footer
- remove unused `openJp` function
- add arrow indicator next to Choose Image label

## Testing
- `npm test --silent` (backend: no tests)
- `npm test --silent -- --watch=false --browsers=ChromeHeadless` (frontend: fails, Chrome missing)

------
https://chatgpt.com/codex/tasks/task_e_685debfd9bd88329862fd3a59b2eb082