### PR TITLE
Add storage note & update footer text

### DIFF
--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -8,5 +8,5 @@
   <router-outlet></router-outlet>
 </main>
 <footer class="credits">
-  <span onclick="window.location.href='https://jpfurlan.dev/';">By Jp</span>
+  <span onclick="window.location.href='https://jpfurlan.dev/';">© 2025 jpfurlan.dev</span>
 </footer>

--- a/frontend/src/app/laser-editor/laser-editor.css
+++ b/frontend/src/app/laser-editor/laser-editor.css
@@ -123,3 +123,9 @@
   font-weight: 600;
 }
 
+.storage-note {
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  color: #999;
+}
+

--- a/frontend/src/app/laser-editor/laser-editor.html
+++ b/frontend/src/app/laser-editor/laser-editor.html
@@ -10,6 +10,7 @@
       />
     </div>
   </div>
+  <p class="storage-note">* No images are stored</p>
 
   <div class="editor">
     <div class="image-container">


### PR DESCRIPTION
## Summary
- add note about not storing uploaded images
- tweak footer text

## Testing
- `npm install`
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_685e865605c8832984cdc511163a77c4