### PR TITLE
Fix footer link style

### DIFF
--- a/frontend/src/app/app.css
+++ b/frontend/src/app/app.css
@@ -34,3 +34,8 @@ footer.credits {
   background: #000;
   color: #fff;
 }
+
+footer.credits a {
+  color: #fff;
+  text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- remove default link styling in the app footer

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e91178e748329aaea73811e7a915b