### PR TITLE
Add how-to dialog link

### DIFF
--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -1,8 +1,9 @@
 <header>
   <h1>LSREYES</h1>
-  <div class="links">
-    <a href="#" (click)="openContribute(); $event.preventDefault()">Contribute</a>
-  </div>
+    <div class="links">
+      <a href="#" (click)="openContribute(); $event.preventDefault()">Contribute</a>
+      <a href="#" (click)="openHowTo(); $event.preventDefault()">How to use it</a>
+    </div>
 </header>
 <main>
   <router-outlet></router-outlet>

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -3,6 +3,7 @@ import { RouterOutlet, RouterLink } from '@angular/router';
 import { LaserEditor } from './laser-editor/laser-editor';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { ContributeDialog } from './contribute-dialog';
+import { HowToDialog } from './howto-dialog';
 import { PayDialog } from './pay-dialog';
 
 @Component({
@@ -14,6 +15,7 @@ import { PayDialog } from './pay-dialog';
     LaserEditor,
     MatDialogModule,
     ContributeDialog,
+    HowToDialog,
     PayDialog,
   ],
   templateUrl: './app.html',
@@ -26,6 +28,9 @@ export class App {
 
   openContribute() {
     this.dialog.open(ContributeDialog);
+  }
+  openHowTo() {
+    this.dialog.open(HowToDialog);
   }
 
 }

--- a/frontend/src/app/contribute-dialog.css
+++ b/frontend/src/app/contribute-dialog.css
@@ -13,4 +13,5 @@ mat-dialog-content {
   flex-direction: column;
   align-items: center;
   text-align: center;
+  padding-top: 8px;
 }

--- a/frontend/src/app/howto-dialog.ts
+++ b/frontend/src/app/howto-dialog.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-howto-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  template: `
+    <h2 mat-dialog-title>How to use it</h2>
+    <mat-dialog-content>
+      <iframe width="560" height="315" src="https://www.youtube.com/embed/yHGI2r-W9X4" frameborder="0" allowfullscreen></iframe>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close>Close</button>
+    </mat-dialog-actions>
+  `,
+})
+export class HowToDialog {}
+


### PR DESCRIPTION
## Summary
- add a link next to Contribute that opens a "How to use it" dialog
- implement the HowToDialog with an embedded YouTube video
- include the new dialog in the app component
- give contribute dialog some top padding for its content

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea8f4902c832982b38d11f9a35742